### PR TITLE
Feature/27 Add new variables for the Java Heap size and the JMX settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [2.1.1](https://github.com/idealista/prometheus_solr_exporter_role/tree/2.1.1)
 ### Added
+- *[#27](https://github.com/idealista/prometheus_solr_exporter_role/issues/24) Add jmx toogle and xmx variables* @santi-eidu
 - *[#24](https://github.com/idealista/prometheus_solr_exporter_role/issues/24) Add service variables* @santi-eidu
 
 ## [2.1.0](https://github.com/idealista/prometheus_solr_exporter_role/tree/2.1.0)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ Variables explanation:
 - `prometheus_solr_exporter_service_location` this is a path location to move the service file
 - `prometheus_solr_exporter_service_name` service name
 - `prometheus_solr_exporter_service_file` the service template file.
-
-
+- `prometheus_solr_exporter_env_file` java environment template file
+- `prometheus_solr_exporter_env_location` this is a path location to move the java environment file
+- `prometheus_solr_exporter_xmx` java heap max size
+- `prometheus_solr_exporter_xms` java heap initial size
+- `prometheus_solr_exporter_java_opts` jvm extra options
 
 Excluding variables:
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Variables explanation:
 - `prometheus_solr_exporter_xmx` java heap max size
 - `prometheus_solr_exporter_xms` java heap initial size
 - `prometheus_solr_exporter_java_opts` jvm extra options
+- `prometheus_solr_exporter_jmx_enabled` jmx enabled or disabled variable
+- `prometheus_solr_exporter_jmx_port` jmx remote port
 
 Excluding variables:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,7 @@ solr_exporter_force_reinstall: false
 prometheus_solr_exporter_service_location: "/etc/systemd/system/prometheus_solr_exporter.service"
 prometheus_solr_exporter_service_name: "prometheus_solr_exporter"
 prometheus_solr_exporter_service_file: prometheus_solr_exporter.service.j2
+prometheus_solr_exporter_env_file: prometheus_solr_exporter.j2
+prometheus_solr_exporter_env_location: "/etc/default/prometheus_solr_exporter"
+prometheus_solr_exporter_xmx: "512m"
+prometheus_solr_exporter_xms: "512m"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,9 +34,11 @@ prometheus_solr_exporter_env_file: prometheus_solr_exporter.j2
 prometheus_solr_exporter_env_location: "/etc/default/prometheus_solr_exporter"
 prometheus_solr_exporter_xmx: "512m"
 prometheus_solr_exporter_xms: "512m"
-prometheus_solr_exporter_java_opts: '-Dcom.sun.management.jmxremote=true
-    -Dcom.sun.management.jmxremote.port=9010
+prometheus_solr_exporter_jmx_port: 9010
+prometheus_solr_exporter_jmx_enabled: true
+prometheus_solr_exporter_java_opts: "-Dcom.sun.management.jmxremote={{ prometheus_solr_exporter_jmx_enabled }}
+    -Dcom.sun.management.jmxremote.port={{ prometheus_solr_exporter_jmx_port }}
     -Dcom.sun.management.jmxremote.local.only=false
     -Dcom.sun.management.jmxremote.authenticate=false
     -Dcom.sun.management.jmxremote.ssl=false
-    -Dlog4j2.formatMsgNoLookups=true'
+    -Dlog4j2.formatMsgNoLookups=true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,9 @@ prometheus_solr_exporter_env_file: prometheus_solr_exporter.j2
 prometheus_solr_exporter_env_location: "/etc/default/prometheus_solr_exporter"
 prometheus_solr_exporter_xmx: "512m"
 prometheus_solr_exporter_xms: "512m"
+prometheus_solr_exporter_java_opts: '-Dcom.sun.management.jmxremote=true
+    -Dcom.sun.management.jmxremote.port=9010
+    -Dcom.sun.management.jmxremote.local.only=false
+    -Dcom.sun.management.jmxremote.authenticate=false
+    -Dcom.sun.management.jmxremote.ssl=false
+    -Dlog4j2.formatMsgNoLookups=true'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: prometheus_solr_exporter
+  hosts: prometheussolrexporter
   vars_files:
     - vars/exporter.yml
   roles:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -80,8 +80,8 @@ platforms:
     exposed_ports:
       - 8983/tcp
 
-  - name: prometheus_solr_exporter
-    hostname: prometheus_solr_exporter
+  - name: prometheussolrexporter
+    hostname: prometheussolrexporter
     image: ${DOCKER_IMAGE_BASE:-idealista/jdk:8u382-bullseye-temurin-jdk}
     privileged: false
     capabilities:

--- a/molecule/default/tests/test_defaut.yml
+++ b/molecule/default/tests/test_defaut.yml
@@ -13,6 +13,10 @@ service:
 port:
   tcp6:{{ prometheus_solr_exporter_port }}:
     listening: true
+{% if prometheus_solr_exporter_jmx_enabled %}
+  tcp6:{{ prometheus_solr_exporter_jmx_port }}:
+    listening: true
+{% endif %}
 
 http:
   http://localhost:{{ prometheus_solr_exporter_port }}:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: Verify
-  hosts: prometheus_solr_exporter
+  hosts: prometheussolrexporter
   vars:
     goss_version: v0.3.7
     goss_arch: amd64

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,13 @@
 ---
+- name: SOLR_EXPORTER | Copying service environment file
+  template:
+    src: "{{ prometheus_solr_exporter_env_file }}"
+    dest: "{{ prometheus_solr_exporter_env_location }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart solr_exporter
+
 - name: SOLR_EXPORTER | Copying service definition
   template:
     src: "{{ prometheus_solr_exporter_service_file }}"

--- a/templates/prometheus_solr_exporter.j2
+++ b/templates/prometheus_solr_exporter.j2
@@ -1,0 +1,1 @@
+JAVA_MEM=-Xmx{{ prometheus_solr_exporter_xmx }} -Xms{{ prometheus_solr_exporter_xms }}

--- a/templates/prometheus_solr_exporter.service.j2
+++ b/templates/prometheus_solr_exporter.service.j2
@@ -6,7 +6,8 @@ After=network.target
 User={{ prometheus_solr_exporter_user }}
 Group={{ prometheus_solr_exporter_group }}
 Type=simple
-Environment='JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true'
+Environment='JAVA_OPTS={{ prometheus_solr_exporter_java_opts }}'
+EnvironmentFile={{ prometheus_solr_exporter_env_location }}
 ExecStart={{ prometheus_solr_exporter_installation_dir }}/contrib/prometheus-exporter/bin/solr-exporter \
             --port {{ prometheus_solr_exporter_port }} \
             {% if prometheus_solr_exporter_solr_mode == 'standalone' %}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This pull request introduces configurable variables for the Java Heap size and the JMX settings. Previously, these values were fixed, limiting flexibility in resource management. The change allows users to modify the Java Heap size and enable or disable JMX. This inprovement add this variables:

- `prometheus_solr_exporter_env_file`
- `prometheus_solr_exporter_env_location`
- `prometheus_solr_exporter_xmx`
- `prometheus_solr_exporter_xms`
- `prometheus_solr_exporter_java_opts` 

### Benefits

<!-- What benefits will be realized by the code change? -->

- Increased Flexibility: Users can now dynamically adjust the Java Heap size according to their needs, optimizing memory usage.

- Enhanced Monitoring: Enabling JMX allows better monitoring and management of Java applications.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

- Configuration Complexity: Introducing new environment variables may add complexity for users unfamiliar with these settings.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#27 
